### PR TITLE
fix: skip claude code review for dependabot PRs

### DIFF
--- a/shared/workflows/claude-code-review.yml
+++ b/shared/workflows/claude-code-review.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   claude-review:
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION
## Summary

Dependabot PRs don't have access to the `CLAUDE_CODE_OAUTH_TOKEN` secret
(GitHub restricts secret access for Dependabot-triggered `pull_request` events).
This causes the Claude Code Review check to fail on every Dependabot PR across
all repos that sync this workflow.

Adds an actor check to skip the review when the PR author is `dependabot[bot]`.

## Changes

- `shared/workflows/claude-code-review.yml` -- add `github.actor != 'dependabot[bot]'` to job condition

## Test Plan

- Verify existing Dependabot PRs no longer show a failing claude-review check after sync
- Verify non-Dependabot PRs still trigger the review as expected