### PR TITLE
chore: add appgrowthco to sync targets

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -52,6 +52,7 @@ jobs:
             [coletoncodes-website]=main
             [family-quest-web]=main
             [flutter-template]=master
+            [appgrowthco]=main
           )
 
           PR_BODY="Automated sync from [ColetonCodes-LLC/.github](https://github.com/ColetonCodes-LLC/.github).


### PR DESCRIPTION
Adds `appgrowthco` (main branch) to the shared config sync targets so it receives:
- Workflows (claude.yml, claude-code-review.yml)
- Rules (architecture, anti-slop, tdd, commits, pull-requests, security, agents)
- Skills (create-pr)