### PR TITLE
chore: add content-os to shared config sync targets

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -54,6 +54,7 @@ jobs:
             [family-quest-web]=main
             [flutter-template]=master
             [appgrowthco]=main
+            [content-os]=main
           )
 
           PR_BODY="Automated sync from [ColetonCodes-LLC/.github](https://github.com/ColetonCodes-LLC/.github).


### PR DESCRIPTION
Adds the new private `content-os` repo to the org shared-config sync targets so it inherits the Claude workflows (claude.yml, claude-code-review.yml), shared rules, and the create-pr skill -- and stays in sync on future updates.

One-line additive change to the TARGETS map. After merge, dispatch `Sync Shared Config` (workflow_dispatch) to open the initial sync PR on content-os.

content-os already inherits the org-wide CLAUDE_CODE_OAUTH_TOKEN, so Claude review works as soon as the workflow lands.